### PR TITLE
Integrate cargo-deny

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 /Cargo.lock
 .env
+.idea

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ readme = "README.md"
 authors = [
     "Foundation Devices <hello@foundationdevices.com>",
 ]
+license = "AGPL-3.0"
 
 [[example]]
 name = "demo"

--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ To view the crate documentation, run `cargo doc --no-deps --open` in the root of
 
 ## LICENSE
 
-GNU Affero General Public License v3.0
+GNU Affero General Public License v3.0 (SPDX: AGPL-3.0)

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,53 @@
+targets = [
+    { triple = "x86_64-unknown-linux-musl" },
+]
+
+[advisories]
+db-path = "~/.cargo/advisory-db"
+db-urls = ["https://github.com/rustsec/advisory-db"]
+vulnerability = "deny"
+unmaintained = "warn"
+yanked = "warn"
+notice = "warn"
+ignore = [
+]
+
+[licenses]
+unlicensed = "deny"
+
+allow = [
+    "MIT",
+    "BSL-1.0",
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "Unicode-DFS-2016" # For `unicode-ident` crate
+]
+
+deny = [
+]
+
+copyleft = "allow"
+allow-osi-fsf-free = "neither"
+default = "deny"
+confidence-threshold = 0.8
+
+[bans]
+multiple-versions = "warn"
+wildcards = "deny"
+highlight = "all"
+
+# List of crates to deny
+deny = [
+]
+
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = [
+]
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+
+# [sources.allow-org]
+# github = ["Foundation-Devices"]


### PR DESCRIPTION
`cargo-deny` allows to lint and keep track of the licenses as well as RUSTSEC security advisories of depending crates.