### PR TITLE
sqlx: enable 'time' feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ once_cell = "1.13"
 prometheus = "0.13"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-sqlx = { version = "0.6", features = ["runtime-tokio-native-tls", "postgres", "offline"] }
+sqlx = { version = "0.6", features = ["runtime-tokio-native-tls", "postgres", "offline", "time"] }
 tokio = { version = "1.0", features = ["full"] }
 tower = "0.4"
 tower-http = { version = "0.3", features = ["cors", "trace"] }


### PR DESCRIPTION
This is to enable static checking of SQL queries (with the [query macro](https://docs.rs/sqlx/latest/sqlx/macro.query.html)) that contain columns of type `TIMESTAMP`

Otherwise this happens:
```
error: optional feature `time` required for type TIMESTAMP of column #7 ("release_date")
   --> src/main.rs:130:18
    |
130 |       let db_res = sqlx::query!("SELECT
    |  __________________^
131 | |     url,
132 | |     version,
133 | |     sha256,
...   |
139 | |     FROM fw_updates
140 | |     WHERE device_id = $1;", device_id)
    | |______________________________________^
    |
    = note: this error originates in the macro `$crate::sqlx_macros::expand_query` (in Nightly builds, run with -Z macro-backtrace for more info)
```