### PR TITLE
http(metrics): record on matched routes only

### DIFF
--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -44,7 +44,7 @@ pub async fn serve<S>(
     // applying handler state if we have it, and default metrics/tracing middleware
     let r = router
         .layer(Extension(state))
-        .layer(middleware::from_fn(metrics::middleware))
+        .route_layer(middleware::from_fn(metrics::middleware)) // only record matched routes
         .layer(
             TraceLayer::new_for_http().make_span_with(
                 DefaultMakeSpan::new()


### PR DESCRIPTION
Opt for using the `axum` [`route_layer`](https://docs.rs/axum/latest/axum/struct.Router.html#method.route_layer) router function for the metrics middleware so we only record metrics on matched routes. Otherwise, for publicly facing services, we can get massive amounts of spam metrics on routes that simply 404 and were never intended to be part of the application.

In the future, something like this could be configurable for some edge case where you would want to record non-matching routes, but I think that is extremely rare and not worth the code at this time.